### PR TITLE
Add security governance files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Default owners for everything
+* @kagenti/maintainers
+
+# Platform and CI
+.github/ @kagenti/platform
+Makefile @kagenti/platform
+
+# Documentation
+docs/ @kagenti/maintainers
+*.md @kagenti/maintainers

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,22 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Secrets and credentials
+.env.*
+.env.local
+*.key
+*.pem
+*.p12
+*.jks
+credentials.*
+secrets.*
+*kubeconfig*
+
+# IDE
+.idea/
+.vscode/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Agent Toolkit
+
+We are grateful for your interest in joining the Kagenti community and making
+a positive impact. Whether you're raising issues, enhancing documentation,
+fixing bugs, or developing new features, your contributions are essential to
+our success.
+
+## Development Setup
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/kagenti/agent-toolkit.git
+   cd agent-toolkit
+   ```
+
+2. Install pre-commit hooks:
+
+   ```bash
+   pip install pre-commit
+   make install-hooks
+   ```
+
+3. Run linting:
+
+   ```bash
+   make lint
+   ```
+
+## Pull Request Process
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes with tests
+4. Run pre-commit hooks: `pre-commit run --all-files`
+5. Submit a pull request
+
+Smaller pull requests are typically easier to review and merge. If your pull
+request is large, collaborate with the maintainers to find the best way to
+divide it.
+
+## Commit Messages
+
+Use conventional commit format:
+
+- `feat:` New features
+- `fix:` Bug fixes
+- `docs:` Documentation changes
+- `chore:` Maintenance tasks
+- `refactor:` Code refactoring
+- `test:` Adding or updating tests
+
+## Certificate of Origin
+
+All commits **must** include a `Signed-off-by` trailer (Developer Certificate
+of Origin). Use the `-s` flag when committing:
+
+```bash
+git commit -s -m "feat: add new feature"
+```
+
+By contributing to this project you agree to the
+[Developer Certificate of Origin](https://developercertificate.org/) (DCO).
+
+## Licensing
+
+Agent Toolkit is [Apache 2.0 licensed](LICENSE) and we accept contributions
+via GitHub pull requests.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take security vulnerabilities seriously. If you discover a security issue,
+please report it responsibly.
+
+### How to Report
+
+1. **Do NOT create public GitHub issues** for security vulnerabilities
+2. **Email**: Report vulnerabilities privately via GitHub Security Advisories
+   - Go to the [Security tab](../../security/advisories/new) and create a new advisory
+3. **Include**: A clear description of the vulnerability, steps to reproduce,
+   and potential impact
+
+### What to Expect
+
+- We will acknowledge receipt within 48 hours
+- We aim to provide an initial assessment within 7 days
+- We will keep you informed of our progress
+- We will credit you in the security advisory (if desired)
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| main    | :white_check_mark: |
+
+## Security Measures
+
+This project implements several security controls:
+
+- **CI/CD Security**: All workflows use explicit least-privilege permissions
+- **Dependency Scanning**: Automated vulnerability scanning via Trivy and Dependabot
+- **Code Analysis**: CodeQL with `security-extended` queries
+- **Supply Chain**: All GitHub Actions SHA-pinned, OpenSSF Scorecard monitoring
+- **Pre-commit Hooks**: Ruff linting and formatting checks


### PR DESCRIPTION
## Summary

Phase 5 of repo orchestration — security governance for agent-toolkit.

- **`.github/CODEOWNERS`** — Default ownership to `@kagenti/maintainers`, platform CI to `@kagenti/platform`
- **`SECURITY.md`** — Vulnerability reporting via GitHub Security Advisories, 48h acknowledgment SLA, documents deployed security controls (Trivy, CodeQL, Dependabot, Scorecard, action pinning)
- **`CONTRIBUTING.md`** — Development setup, PR process, conventional commits, DCO sign-off requirement
- **`.gitignore`** — Hardened with secrets/credentials patterns (`.env.*`, `*.key`, `*.pem`, `*kubeconfig*`), IDE (`.idea/`, `.vscode/`), and OS files (`.DS_Store`)

### Branch protection recommendations

After merging, configure these branch protection rules for `main`:

- [ ] Require PR reviews (minimum 1 approval)
- [ ] Require status checks: `Lint & Test`, `Dependency Review`, `Trivy Filesystem Scan`, `CodeQL Analysis`, `Verify Action Pinning`
- [ ] Disable force push to main
- [ ] Require branches to be up to date before merging
- [ ] Require conversation resolution before merging

## Test plan

- [ ] Verify CODEOWNERS assigns reviewers on a test PR
- [ ] Verify SECURITY.md links to correct security advisory page
- [ ] Verify .gitignore excludes `.env.local`, `*.pem`, `.idea/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)