### PR TITLE
refactor: migrate image registries from i-am-bee to kagenti

### DIFF
--- a/agent-registry.yaml
+++ b/agent-registry.yaml
@@ -1,5 +1,5 @@
 providers:
-  - location: ghcr.io/i-am-bee/agentstack/agents/chat:0.7.1
-  - location: ghcr.io/i-am-bee/agentstack/agents/rag:0.7.1
-  - location: ghcr.io/i-am-bee/agentstack/agents/canvas:0.7.1
-  - location: ghcr.io/i-am-bee/agentstack/agents/form:0.7.1
+  - location: ghcr.io/kagenti/adk/agents/chat:0.7.1
+  - location: ghcr.io/kagenti/adk/agents/rag:0.7.1
+  - location: ghcr.io/kagenti/adk/agents/canvas:0.7.1
+  - location: ghcr.io/kagenti/adk/agents/form:0.7.1

--- a/apps/agentstack-server/tasks.toml
+++ b/apps/agentstack-server/tasks.toml
@@ -112,7 +112,7 @@ run = "uv run agentstack-server"
 ["agentstack-server:build"]
 depends = ["agentstack-server:build:*"]
 dir = "{{config_root}}/apps/agentstack-server"
-run = "docker build -t ghcr.io/i-am-bee/agentstack/agentstack-server:local --load ."
+run = "docker build -t ghcr.io/kagenti/adk/adk-server:local --load ."
 
 ["agentstack-server:build:requirements"]
 depends = ["agentstack-server:setup"]

--- a/apps/agentstack-ui/tasks.toml
+++ b/apps/agentstack-ui/tasks.toml
@@ -69,7 +69,7 @@ run = "pnpm next dev --webpack"
 ["agentstack-ui:build"]
 depends = ["agentstack-ui:build:*"]
 dir = "{{config_root}}"
-run = "docker build -t ghcr.io/i-am-bee/agentstack/agentstack-ui:local -f ./apps/agentstack-ui/Dockerfile --load ."
+run = "docker build -t ghcr.io/kagenti/adk/adk-ui:local -f ./apps/agentstack-ui/Dockerfile --load ."
 
 ["agentstack-ui:build:nextjs"]
 depends = ["common:setup:pnpm", "adk-ts:build"]

--- a/docs/development/deploy-agent-stack/deployment-guide.mdx
+++ b/docs/development/deploy-agent-stack/deployment-guide.mdx
@@ -54,12 +54,12 @@ are explained in the [Configuration Options](#configuration-options) section.
 ```yaml
 # External registries for default catalogs (change release/tag accordingly):
 externalRegistries:
-  public_github: "https://github.com/i-am-bee/agentstack@v0.4.3#path=agent-registry.yaml"
+  public_github: "https://github.com/kagenti/adk@v0.4.3#path=agent-registry.yaml"
 
 # Custom agents as docker images
 providers:
   - location: <docker-image-id>
-  # e.g. location: ghcr.io/i-am-bee/agentstack-starter/my-agent:latest
+  # e.g. location: ghcr.io/kagenti/adk-starter/my-agent:latest
 
 # Use the key generated in Step 1
 encryptionKey: "encryption-key-from-command"
@@ -77,7 +77,7 @@ auth:
 Deploy the stack to your cluster using Helm. 
 
 ```shell
-helm upgrade --install agentstack -f config.yaml oci://ghcr.io/i-am-bee/agentstack/chart/agentstack:0.4.3
+helm upgrade --install agentstack -f config.yaml oci://ghcr.io/kagenti/adk/chart/adk:0.4.3
 ```
 It may take a few minutes for the pods to start.
 
@@ -460,9 +460,9 @@ Use this method to manually define specific agent images and their unique enviro
 ```yaml
 providers:
   # Official agents
-  - location: ghcr.io/i-am-bee/agentstack/agents/chat:0.4.3
-  - location: ghcr.io/i-am-bee/agentstack/agents/rag:0.4.3
-  - location: ghcr.io/i-am-bee/agentstack/agents/form:0.4.3
+  - location: ghcr.io/kagenti/adk/agents/chat:0.4.3
+  - location: ghcr.io/kagenti/adk/agents/rag:0.4.3
+  - location: ghcr.io/kagenti/adk/agents/form:0.4.3
 
   # Your custom agents
   - location: your-registry.com/your-team/custom-agent:v1.0.0
@@ -480,7 +480,7 @@ To upgrade an agent, change its version tag and redeploy using `helm upgrade`.
 Instead of manual listing, you can point to a remote registry file. This is ideal for teams managing a large, dynamic catalog of agents.
 ```yaml
 externalRegistries:
-  public_github: "https://github.com/i-am-bee/agentstack@v0.4.3#path=agent-registry.yaml"
+  public_github: "https://github.com/kagenti/adk@v0.4.3#path=agent-registry.yaml"
 ```
 
 To upgrade an agent, change its version in the registry and wait for automatic synchronization (up to 10 minutes).
@@ -527,7 +527,7 @@ providerBuilds:
 
 The guide above covers the primary configuration paths for production environments. For a comprehensive list of every available parameter, including low-level resource limits, node selectors, and detailed sub-chart settings, refer to the source configuration file.
 
-All configuration options, including their default values and technical descriptions, are documented in the [values.yaml file](https://github.com/i-am-bee/agentstack/blob/v0.4.3/helm/values.yaml) within the official repository.
+All configuration options, including their default values and technical descriptions, are documented in the [values.yaml file](https://github.com/kagenti/adk/blob/v0.4.3/helm/values.yaml) within the official repository.
 
 If your infrastructure has specific requirements (such as custom sidecars, unique volume mounts, or specific network policies) that are not currently exposed via the Helm chart, please open a GitHub issue to request a new configuration toggle.
 
@@ -540,7 +540,7 @@ Once Agent Stack is running, use these Helm and `kubectl` commands to manage the
 
 | Task | Command |
 |------|---------|
-| Upgrade Platform | `helm upgrade --install agentstack -f config.yaml oci://ghcr.io/i-am-bee/agentstack/chart/agentstack:<version>` |
+| Upgrade Platform | `helm upgrade --install agentstack -f config.yaml oci://ghcr.io/kagenti/adk/chart/adk:<version>` |
 | View Active Config | `helm get values agentstack` |
 | Deployment Status | `helm status agentstack` |
 | Resource Health | `kubectl get pods` , `kubectl logs deployment/agentstack-server` |

--- a/docs/stable/deploy-agent-stack/deployment-guide.mdx
+++ b/docs/stable/deploy-agent-stack/deployment-guide.mdx
@@ -54,12 +54,12 @@ are explained in the [Configuration Options](#configuration-options) section.
 ```yaml
 # External registries for default catalogs (change release/tag accordingly):
 externalRegistries:
-  public_github: "https://github.com/i-am-bee/agentstack@v0.4.3#path=agent-registry.yaml"
+  public_github: "https://github.com/kagenti/adk@v0.4.3#path=agent-registry.yaml"
 
 # Custom agents as docker images
 providers:
   - location: <docker-image-id>
-  # e.g. location: ghcr.io/i-am-bee/agentstack-starter/my-agent:latest
+  # e.g. location: ghcr.io/kagenti/adk-starter/my-agent:latest
 
 # Use the key generated in Step 1
 encryptionKey: "encryption-key-from-command"
@@ -77,7 +77,7 @@ auth:
 Deploy the stack to your cluster using Helm. 
 
 ```shell
-helm upgrade --install agentstack -f config.yaml oci://ghcr.io/i-am-bee/agentstack/chart/agentstack:0.4.3
+helm upgrade --install agentstack -f config.yaml oci://ghcr.io/kagenti/adk/chart/adk:0.4.3
 ```
 It may take a few minutes for the pods to start.
 
@@ -459,9 +459,9 @@ Use this method to manually define specific agent images and their unique enviro
 ```yaml
 providers:
   # Official agents
-  - location: ghcr.io/i-am-bee/agentstack/agents/chat:0.4.3
-  - location: ghcr.io/i-am-bee/agentstack/agents/rag:0.4.3
-  - location: ghcr.io/i-am-bee/agentstack/agents/form:0.4.3
+  - location: ghcr.io/kagenti/adk/agents/chat:0.4.3
+  - location: ghcr.io/kagenti/adk/agents/rag:0.4.3
+  - location: ghcr.io/kagenti/adk/agents/form:0.4.3
 
   # Your custom agents
   - location: your-registry.com/your-team/custom-agent:v1.0.0
@@ -479,7 +479,7 @@ To upgrade an agent, change its version tag and redeploy using `helm upgrade`.
 Instead of manual listing, you can point to a remote registry file. This is ideal for teams managing a large, dynamic catalog of agents.
 ```yaml
 externalRegistries:
-  public_github: "https://github.com/i-am-bee/agentstack@v0.4.3#path=agent-registry.yaml"
+  public_github: "https://github.com/kagenti/adk@v0.4.3#path=agent-registry.yaml"
 ```
 
 To upgrade an agent, change its version in the registry and wait for automatic synchronization (up to 10 minutes).
@@ -526,7 +526,7 @@ providerBuilds:
 
 The guide above covers the primary configuration paths for production environments. For a comprehensive list of every available parameter, including low-level resource limits, node selectors, and detailed sub-chart settings, refer to the source configuration file.
 
-All configuration options, including their default values and technical descriptions, are documented in the [values.yaml file](https://github.com/i-am-bee/agentstack/blob/v0.4.3/helm/values.yaml) within the official repository.
+All configuration options, including their default values and technical descriptions, are documented in the [values.yaml file](https://github.com/kagenti/adk/blob/v0.4.3/helm/values.yaml) within the official repository.
 
 If your infrastructure has specific requirements (such as custom sidecars, unique volume mounts, or specific network policies) that are not currently exposed via the Helm chart, please open a GitHub issue to request a new configuration toggle.
 
@@ -539,7 +539,7 @@ Once Agent Stack is running, use these Helm and `kubectl` commands to manage the
 
 | Task | Command |
 |------|---------|
-| Upgrade Platform | `helm upgrade --install agentstack -f config.yaml oci://ghcr.io/i-am-bee/agentstack/chart/agentstack:<version>` |
+| Upgrade Platform | `helm upgrade --install agentstack -f config.yaml oci://ghcr.io/kagenti/adk/chart/adk:<version>` |
 | View Active Config | `helm get values agentstack` |
 | Deployment Status | `helm status agentstack` |
 | Resource Health | `kubectl get pods` , `kubectl logs deployment/agentstack-server` |

--- a/helm/README.md
+++ b/helm/README.md
@@ -4,7 +4,7 @@ The agent stack helm chart is packaged and uploaded to the container registry fo
 You can install the chart using the following command:
 
 ```bash
-helm install agentstack -f config.yaml oci://ghcr.io/i-am-bee/agentstack/chart/agentstack:<release-version>
+helm install agentstack -f config.yaml oci://ghcr.io/kagenti/adk/chart/adk:<release-version>
 ```
 
 Check out the [documentation](https://agentstack.beeai.dev/stable/how-to/deployment-guide) for a detailed deployment guide.

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -49,9 +49,9 @@ Resources:
 
     Documentation: https://agentstack.beeai.dev
     Discord Community: https://discord.gg/NradeA6ZNF
-    GitHub Issues: https://github.com/i-am-bee/agentstack/issues
+    GitHub Issues: https://github.com/kagenti/adk/issues
 
 Upgrade platform:
 
-    helm upgrade {{ .Release.Name }} oci://ghcr.io/i-am-bee/agentstack/chart/agentstack:<version>
+    helm upgrade {{ .Release.Name }} oci://ghcr.io/kagenti/adk/chart/adk:<version>
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -208,7 +208,7 @@ imagePullSecrets: []
 # -------- SERVER ----------
 server:
   image:
-    repository: ghcr.io/i-am-bee/agentstack/agentstack-server
+    repository: ghcr.io/kagenti/adk/adk-server
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: null
@@ -352,7 +352,7 @@ ui:
   enabled: true
   appName: "Agent Stack"
   image:
-    repository: ghcr.io/i-am-bee/agentstack/agentstack-ui
+    repository: ghcr.io/kagenti/adk/adk-ui
     pullPolicy: IfNotPresent
     tag: null
     resources: {}
@@ -394,7 +394,7 @@ postgresql:
       allowInsecureImages: true
   image:
     registry: ghcr.io
-    repository: i-am-bee/bitnami/postgresql-pgvector
+    repository: kagenti/bitnami/postgresql-pgvector
     tag: 17.6.0@sha256:2af2dbe1216541ecfab4dc0552ef332034e6ac1e7aa2f4124417145b196ed17a
   auth:
     postgresPassword: "admin-password"
@@ -463,7 +463,7 @@ seaweedfs:
   enabled: true
   image:
     registry: ghcr.io
-    repository: i-am-bee/chrislusf # Should be i-am-bee/chrislusf/seaweedfs, there is a bug in the subchart
+    repository: kagenti/chrislusf # Should be kagenti/chrislusf/seaweedfs, there is a bug in the subchart
   bucket: "agentstack-files"
   auth:
     admin:
@@ -532,7 +532,7 @@ redis:
   fullnameOverride: "redis"
   image:
     registry: ghcr.io
-    repository: i-am-bee/redis
+    repository: kagenti/redis
   architecture: standalone
   auth:
     enabled: true

--- a/tasks.toml
+++ b/tasks.toml
@@ -382,7 +382,7 @@ echo -e "✅ Updated \x1b[36minstall.sh\x1b[0m on \x1b[36mmain\x1b[0m to install
 
 git checkout $release_branch
 
-echo -e "💡 Check the pipeline progress and result on: https://github.com/i-am-bee/agentstack/actions/workflows/release.yml"
+echo -e "💡 Check the pipeline progress and result on: https://github.com/kagenti/adk/actions/workflows/release.yml"
 '''
 
 ["release:publish-stable"]
@@ -480,7 +480,7 @@ git push origin main
 set +x
 echo -e "✅ Published \x1b[36mstable\x1b[0m docs for \x1b[36mv$publish_version\x1b[0m"
 
-echo "💡 Check the pipeline progress and result on: https://github.com/i-am-bee/agentstack/actions/workflows/release.yml"
+echo "💡 Check the pipeline progress and result on: https://github.com/kagenti/adk/actions/workflows/release.yml"
 '''
 
 # misc tasks
@@ -530,8 +530,8 @@ echo "$images" | while IFS= read -r ghcr_image; do
     ghcr_image=$(echo "$ghcr_image" | sed 's/:[^:/]*@/@/')
   fi
 
-  # Remove ghcr.io/i-am-bee/ prefix to get Docker Hub image
-  if [[ $ghcr_image =~ ^ghcr\.io/i-am-bee/(.+)$ ]]; then
+  # Remove ghcr.io/kagenti/ prefix to get Docker Hub image
+  if [[ $ghcr_image =~ ^ghcr\.io/kagenti/(.+)$ ]]; then
     dockerhub_image="${BASH_REMATCH[1]}"
 
     echo "GHCR image: $ghcr_image"
@@ -618,7 +618,7 @@ git fetch origin --tags --quiet
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Latest release branch:  $(git branch -r --sort=-version:refname --format "%(refname:short)" | grep 'origin/release-v' | head -n1 | sed 's|origin/||')"
 echo "Latest released tag:    $(git ls-remote --tags origin 'v*' | grep -o 'refs/tags/v[0-9]*\.[0-9]*\.[0-9]*\(-rc[0-9]*\)\?$' | sed 's|refs/tags/||' | sort -V | tail -n 1)"
-echo "CI status:              https://github.com/i-am-bee/agentstack/actions/workflows/release.yml"
+echo "CI status:              https://github.com/kagenti/adk/actions/workflows/release.yml"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 '''
 
@@ -736,7 +736,7 @@ run = '''
 #!/usr/bin/env bash
 set -euo pipefail
 
-gh api repos/i-am-bee/agentstack/dependabot/alerts --paginate 2>&1 | uv run python3 -c "
+gh api repos/kagenti/adk/dependabot/alerts --paginate 2>&1 | uv run python3 -c "
 import json, sys
 data = []
 for line in sys.stdin:


### PR DESCRIPTION
## Summary
- Migrate all `ghcr.io/i-am-bee/agentstack/...` image references to `ghcr.io/kagenti/adk/...`
- Update third-party mirror references (`bitnami/postgresql-pgvector`, `chrislusf`, `redis`) from `i-am-bee` to `kagenti` org
- Update Helm chart OCI URLs, GitHub URLs, and CI pipeline links across docs, tasks, and templates

Closes #18

## Test plan
- [x] `grep -r 'ghcr.io/i-am-bee' .` returns no results
- [x] `mise run check` passes (linting, type checking, helm lint/render, broken links, version consistency)