### PR TITLE
fix(test): update AgentCard for a2a-sdk v1

### DIFF
--- a/apps/adk-server/tests/e2e/agents/test_agent_starts.py
+++ b/apps/adk-server/tests/e2e/agents/test_agent_starts.py
@@ -8,7 +8,6 @@ import contextlib
 import time
 import uuid
 from threading import Thread
-from typing import Any
 from unittest import mock
 
 import pytest
@@ -105,17 +104,16 @@ async def test_imported_agent(
             await get_final_task_from_stream(a2a_client.send_message(SendMessageRequest(message=message)))
 
 
-EXTERNAL_AGENT_CARD: dict[str, Any] = {
-    "authentication": {"schemes": ["Bearer"]},
-    "capabilities": AgentCapabilities(streaming=True),
-    "defaultInputModes": ["text/plain"],
-    "defaultOutputModes": ["text/plain"],
-    "description": "Test external A2A agent",
-    "name": "ExternalTestAgent",
-    "skills": [{"id": "skill-1", "name": "Echo", "description": "Echoes back", "tags": ["test"]}],
-    "url": "http://example.com/agent",
-    "version": "1.0",
-}
+EXTERNAL_AGENT_CARD = AgentCard(
+    capabilities=AgentCapabilities(streaming=True),
+    default_input_modes=["text/plain"],
+    default_output_modes=["text/plain"],
+    description="Test external A2A agent",
+    name="ExternalTestAgent",
+    skills=[AgentSkill(id="skill-1", name="Echo", description="Echoes back", tags=["test"])],
+    supported_interfaces=[AgentInterface(url="http://example.com/agent", protocol_binding="JSONRPC")],
+    version="1.0",
+)
 
 
 
@@ -124,8 +122,10 @@ def external_a2a_server(free_port, setup_platform_client, clean_up_fn):
     server_instance: uvicorn.Server | None = None
     thread: Thread | None = None
 
-    agent_card = AgentCard(**EXTERNAL_AGENT_CARD)
-    agent_card.url = f"http://host.docker.internal:{free_port}"
+    agent_card = AgentCard()
+    agent_card.CopyFrom(EXTERNAL_AGENT_CARD)
+    for interface in agent_card.supported_interfaces:
+        interface.url = f"http://host.docker.internal:{free_port}"
 
     executor = mock.AsyncMock(spec=AgentExecutor)
     http_handler = DefaultRequestHandler(agent_executor=executor, task_store=InMemoryTaskStore())

--- a/examples/agent-integration/agent-details/basic-configuration/uv.lock
+++ b/examples/agent-integration/agent-details/basic-configuration/uv.lock
@@ -4,8 +4,8 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "a2a-sdk"
-version = "1.0.0a0.post4.dev0+24f5f1e"
-source = { git = "https://github.com/a2aproject/a2a-python.git?rev=1.0-dev#24f5f1e5c4184a36bb99cff6e7c44db4176b72be" }
+version = "1.0.0a0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "googleapis-common-protos" },
@@ -14,6 +14,10 @@ dependencies = [
     { name = "json-rpc" },
     { name = "protobuf" },
     { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e3/e0d0b93877dc7d7ad45d59f82a254664e8d78f35fe20c8cd8584eb9bcba0/a2a_sdk-1.0.0a0.tar.gz", hash = "sha256:83ee525015b8577091750ea823af1afe41ccf350789539e421b0ab06d3622eb2", size = 343086, upload-time = "2026-03-17T14:11:04.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/f7/673b61a8272c9d36baf9df7169a784e6eda214a830569e9f0c3e442d75bb/a2a_sdk-1.0.0a0-py3-none-any.whl", hash = "sha256:a062e00a00d0fffcdd4325c36392dff27bf0e9ef99a6a6d35344c08676ca45c4", size = 225939, upload-time = "2026-03-17T14:11:02.672Z" },
 ]
 
 [package.optional-dependencies]
@@ -510,7 +514,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["sqlite"], git = "https://github.com/a2aproject/a2a-python.git?rev=1.0-dev" },
+    { name = "a2a-sdk", extras = ["sqlite"], specifier = "==1.0.0a0" },
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "async-lru", specifier = ">=2.0.4" },
     { name = "asyncclick", specifier = ">=8.1.8" },

--- a/examples/agent-integration/agent-settings/basic-settings/uv.lock
+++ b/examples/agent-integration/agent-settings/basic-settings/uv.lock
@@ -4,8 +4,8 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "a2a-sdk"
-version = "1.0.0a0.post4.dev0+24f5f1e"
-source = { git = "https://github.com/a2aproject/a2a-python.git?rev=1.0-dev#24f5f1e5c4184a36bb99cff6e7c44db4176b72be" }
+version = "1.0.0a0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "googleapis-common-protos" },
@@ -14,6 +14,10 @@ dependencies = [
     { name = "json-rpc" },
     { name = "protobuf" },
     { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e3/e0d0b93877dc7d7ad45d59f82a254664e8d78f35fe20c8cd8584eb9bcba0/a2a_sdk-1.0.0a0.tar.gz", hash = "sha256:83ee525015b8577091750ea823af1afe41ccf350789539e421b0ab06d3622eb2", size = 343086, upload-time = "2026-03-17T14:11:04.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/f7/673b61a8272c9d36baf9df7169a784e6eda214a830569e9f0c3e442d75bb/a2a_sdk-1.0.0a0-py3-none-any.whl", hash = "sha256:a062e00a00d0fffcdd4325c36392dff27bf0e9ef99a6a6d35344c08676ca45c4", size = 225939, upload-time = "2026-03-17T14:11:02.672Z" },
 ]
 
 [package.optional-dependencies]
@@ -510,7 +514,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["sqlite"], git = "https://github.com/a2aproject/a2a-python.git?rev=1.0-dev" },
+    { name = "a2a-sdk", extras = ["sqlite"], specifier = "==1.0.0a0" },
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "async-lru", specifier = ">=2.0.4" },
     { name = "asyncclick", specifier = ">=8.1.8" },

--- a/examples/agent-integration/canvas/canvas-with-llm/uv.lock
+++ b/examples/agent-integration/canvas/canvas-with-llm/uv.lock
@@ -4,8 +4,8 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "a2a-sdk"
-version = "1.0.0a0.post4.dev0+24f5f1e"
-source = { git = "https://github.com/a2aproject/a2a-python.git?rev=1.0-dev#24f5f1e5c4184a36bb99cff6e7c44db4176b72be" }
+version = "1.0.0a0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
     { name = "googleapis-common-protos" },
@@ -14,6 +14,10 @@ dependencies = [
     { name = "json-rpc" },
     { name = "protobuf" },
     { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e3/e0d0b93877dc7d7ad45d59f82a254664e8d78f35fe20c8cd8584eb9bcba0/a2a_sdk-1.0.0a0.tar.gz", hash = "sha256:83ee525015b8577091750ea823af1afe41ccf350789539e421b0ab06d3622eb2", size = 343086, upload-time = "2026-03-17T14:11:04.071Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/f7/673b61a8272c9d36baf9df7169a784e6eda214a830569e9f0c3e442d75bb/a2a_sdk-1.0.0a0-py3-none-any.whl", hash = "sha256:a062e00a00d0fffcdd4325c36392dff27bf0e9ef99a6a6d35344c08676ca45c4", size = 225939, upload-time = "2026-03-17T14:11:02.672Z" },
 ]
 
 [package.optional-dependencies]
@@ -510,7 +514,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", extras = ["sqlite"], git = "https://github.com/a2aproject/a2a-python.git?rev=1.0-dev" },
+    { name = "a2a-sdk", extras = ["sqlite"], specifier = "==1.0.0a0" },
     { name = "anyio", specifier = ">=4.9.0" },
     { name = "async-lru", specifier = ">=2.0.4" },
     { name = "asyncclick", specifier = ">=8.1.8" },


### PR DESCRIPTION
## Summary
- Fix `test_external_a2a_agent` failing with `ValueError: Protocol message AgentCard has no "authentication" field`
- Update `EXTERNAL_AGENT_CARD` to use a2a-sdk v1 protobuf schema: remove deprecated `authentication` field, use `supported_interfaces` instead of `url`, and use snake_case field names (`default_input_modes`, `default_output_modes`)
- Update fixture to set URL via `supported_interfaces` loop instead of the removed `agent_card.url`

## Test plan
- [ ] CI passes `test_external_a2a_agent` without the `AgentCard has no "authentication" field` error