### PR TITLE
refactor(examples): rename BeeAI to Kagenti and AgentStack to ADK

### DIFF
--- a/docs/development/agent-integration/agent-details.mdx
+++ b/docs/development/agent-integration/agent-details.mdx
@@ -18,7 +18,7 @@ Configuring agent details is straightforward. Import `AgentDetail` and related t
 
 {/* <!-- embedme examples/agent-integration/agent-details/basic-configuration/src/basic_configuration/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -43,9 +43,9 @@ server = Server()
                 name="Document Reader", description="Reads and extracts key insights from uploaded PDFs or text files."
             ),
         ],
-        framework="BeeAI Framework",
+        framework="Kagenti ADK",
         author=AgentDetailContributor(
-            name="Agent Stack Team",
+            name="ADK Team",
             email="team@example.com",
         ),
         source_code_url="https://github.com/example/example-research-assistant",

--- a/docs/development/agent-integration/agent-settings.mdx
+++ b/docs/development/agent-integration/agent-settings.mdx
@@ -42,7 +42,7 @@ Here's how to add simple user defined settings to your agent:
 
 {/* <!-- embedme examples/agent-integration/agent-settings/basic-settings/src/basic_settings/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/citations.mdx
+++ b/docs/development/agent-integration/citations.mdx
@@ -21,7 +21,7 @@ Each citation requires:
 
 {/* <!-- embedme examples/agent-integration/citations/citation-basic-usage/src/citation_basic_usage/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/env-variables.mdx
+++ b/docs/development/agent-integration/env-variables.mdx
@@ -21,7 +21,7 @@ Here's how to request environment variables for your agent:
 
 {/* <!-- embedme examples/agent-integration/env-variables/basic-environment-variables/src/basic_environment_variables/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/error.mdx
+++ b/docs/development/agent-integration/error.mdx
@@ -13,7 +13,7 @@ Simply raise exceptions in your agent code. The SDK will catch them and use the 
 
 {/* <!-- embedme examples/agent-integration/error/standard-error-reporting/src/standard_error_reporting/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -46,7 +46,7 @@ If you want to customize the error reporting, for example to include stack trace
 
 {/* <!-- embedme examples/agent-integration/error/advanced-error-reporting/src/advanced_error_reporting/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -110,7 +110,7 @@ The Error extension supports `ExceptionGroup` to report multiple errors at once.
 
 {/* <!-- embedme examples/agent-integration/error/multiple-errors-handling/src/multiple_errors_handling/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -142,7 +142,7 @@ You can attach arbitrary context to errors by accessing the injected `ErrorExten
 
 {/* <!-- embedme examples/agent-integration/error/adding-error-context/src/adding_error_context/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/files.mdx
+++ b/docs/development/agent-integration/files.mdx
@@ -11,7 +11,7 @@ Here's how to build an agent that can accept and modify files:
 
 {/* <!-- embedme examples/agent-integration/files/file-processing/src/file_processing/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/forms.mdx
+++ b/docs/development/agent-integration/forms.mdx
@@ -16,7 +16,7 @@ For initial form rendering, you specify the form structure when injecting the ex
 
 {/* <!-- embedme examples/agent-integration/forms/initial-form-rendering/src/initial_form_rendering/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -97,7 +97,7 @@ For dynamic form requests during conversation, you can request forms at any poin
 
 {/* <!-- embedme examples/agent-integration/forms/dynamic-form-requests/src/dynamic_form_requests/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/llm-proxy-service.mdx
+++ b/docs/development/agent-integration/llm-proxy-service.mdx
@@ -128,7 +128,7 @@ This complete example shows how to receive a user message and respond using the 
 
 {/* <!-- embedme examples/agent-integration/llm-proxy-service/llm-access/src/llm_access/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/mcp.mdx
+++ b/docs/development/agent-integration/mcp.mdx
@@ -64,7 +64,7 @@ Here's an example agent that uses the GitHub MCP Connector and returns your prof
 
 {/* <!-- embedme examples/agent-integration/mcp/github-mcp-agent/src/github_mcp_agent/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import json
@@ -146,7 +146,7 @@ Here's how to build an agent that creates a custom MCP client and uses OAuth for
 
 {/* <!-- embedme examples/agent-integration/mcp/custom-mcp-client-with-oauth/src/custom_mcp_client_with_oauth/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/multi-turn.mdx
+++ b/docs/development/agent-integration/multi-turn.mdx
@@ -21,7 +21,7 @@ Here's an example agent that maintains conversation history and counts the numbe
 
 {/* <!-- embedme examples/agent-integration/multi-turn/basic-history/src/basic_history/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -85,7 +85,7 @@ This is usecase-specific and one my opt for a combination of this and previous a
 
 {/* <!-- embedme examples/agent-integration/multi-turn/streaming-agent-history/src/streaming_agent_history/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os
@@ -193,7 +193,7 @@ Here's a sophisticated example using the BeeAI Framework to build a multi-turn c
 
 {/* <!-- embedme examples/agent-integration/multi-turn/advanced-history/src/advanced_history/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -218,7 +218,7 @@ FrameworkMessage = UserMessage | AssistantMessage
 
 
 def to_framework_message(message: Message) -> FrameworkMessage:
-    """Convert A2A Message to BeeAI Framework Message format"""
+    """Convert A2A Message to Kagenti ADK Message format"""
     message_text = "".join(part.root.text for part in message.parts if part.root.kind == "text")
 
     if message.role == Role.agent:
@@ -241,7 +241,7 @@ async def advanced_history_example(
     # Load conversation history
     history = [message async for message in context.load_history() if isinstance(message, Message) and message.parts]
 
-    # Initialize BeeAI Framework LLM client
+    # Initialize Kagenti ADK LLM client
     llm_client = AgentStackChatModel(tool_choice_support={"none", "auto"})
     llm_client.set_context(llm)
 

--- a/docs/development/agent-integration/overview.mdx
+++ b/docs/development/agent-integration/overview.mdx
@@ -25,7 +25,7 @@ Here we show server creation and agent registration:
 
 {/* <!-- embedme examples/agent-integration/overview/server-wrapper/src/server_wrapper/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -63,7 +63,7 @@ Here's an example that incorporates multiple Server SDK capabilities:
 
 {/* <!-- embedme examples/agent-integration/overview/advanced-server-wrapper/src/advanced_server_wrapper/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -171,7 +171,7 @@ Service extensions use a dependency injection pattern where each run of the agen
 
 {/* <!-- embedme examples/agent-integration/overview/dependency-injection/src/dependency_injection/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/rag.mdx
+++ b/docs/development/agent-integration/rag.mdx
@@ -171,7 +171,7 @@ the result. After extraction is completed, the `extraction` object will contain
 
 {/* <!-- embedme examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/extraction.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
@@ -207,7 +207,7 @@ This will split a long document into reasonably sized chunks based on the Markdo
 
 {/* <!-- embedme examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/text_splitting.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from langchain_text_splitters import MarkdownTextSplitter
@@ -226,7 +226,7 @@ to create an `AsyncOpenAI` client:
 
 {/* <!-- embedme examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/embedding/client.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.a2a.extensions import EmbeddingServiceExtensionServer
@@ -253,7 +253,7 @@ Now we can use this client to generate embeddings for our chunks and create vect
 
 {/* <!-- embedme examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/embedding/embed.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.platform import File, VectorStoreItem
@@ -291,7 +291,7 @@ it in advance, we will create a test embedding request to calculate the dimensio
 
 {/* <!-- embedme examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/vector_store/create.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.platform import VectorStore
@@ -318,7 +318,7 @@ query. The following function will retrieve five document chunks most similar to
 
 {/* <!-- embedme examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/vector_store/search.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.platform import VectorStore, VectorStoreSearchResult
@@ -349,7 +349,7 @@ user query as `TextPart`. A new vector store is created for each message.
 
 {/* <!-- embedme examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import json
@@ -461,7 +461,7 @@ messages so you can ask multiple queries and or additional documents later on.
 
 {/* <!-- embedme examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/agent.py--> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/docs/development/agent-integration/secrets.mdx
+++ b/docs/development/agent-integration/secrets.mdx
@@ -15,7 +15,7 @@ Here's how to add secrets capabilities to your agent:
 
 {/* <!-- embedme examples/agent-integration/secrets/basic-secrets/src/basic_secrets/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/agent-integration/tool-calls.mdx
+++ b/docs/development/agent-integration/tool-calls.mdx
@@ -12,7 +12,7 @@ This example uses the [BeeAI Framework](https://framework.beeai.dev/modules/agen
 
 {/* <!-- embedme examples/agent-integration/tool-calls/basic-approve/src/basic_approve/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 import os
 from typing import Annotated, Any

--- a/docs/development/agent-integration/trajectory.mdx
+++ b/docs/development/agent-integration/trajectory.mdx
@@ -11,7 +11,7 @@ making the interaction more transparent and trustworthy.
 
 {/* <!-- embedme examples/agent-integration/trajectory/trajectory-basic-usage/src/trajectory_basic_usage/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/docs/development/deploy-agents/building-agents.mdx
+++ b/docs/development/deploy-agents/building-agents.mdx
@@ -66,7 +66,7 @@ The starter example is minimal and intended for demonstration purposes only:
 
 {/* <!-- embedme examples/deploy-agents/building-agents/implement-your-agent-logic/src/implement_your_agent_logic/agent.py --> */}
 ```python
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/.template/example/src/example_name/__init__.py
+++ b/examples/.template/example/src/example_name/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/.template/example/src/example_name/agent.py
+++ b/examples/.template/example/src/example_name/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/.template/test.py
+++ b/examples/.template/test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/examples/agent-integration/agent-details/basic-configuration/src/basic_configuration/__init__.py
+++ b/examples/agent-integration/agent-details/basic-configuration/src/basic_configuration/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/agent-details/basic-configuration/src/basic_configuration/agent.py
+++ b/examples/agent-integration/agent-details/basic-configuration/src/basic_configuration/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -23,9 +23,9 @@ server = Server()
                 name="Document Reader", description="Reads and extracts key insights from uploaded PDFs or text files."
             ),
         ],
-        framework="BeeAI Framework",
+        framework="Kagenti ADK",
         author=AgentDetailContributor(
-            name="Agent Stack Team",
+            name="ADK Team",
             email="team@example.com",
         ),
         source_code_url="https://github.com/example/example-research-assistant",

--- a/examples/agent-integration/agent-settings/basic-settings/src/basic_settings/__init__.py
+++ b/examples/agent-integration/agent-settings/basic-settings/src/basic_settings/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/agent-settings/basic-settings/src/basic_settings/agent.py
+++ b/examples/agent-integration/agent-settings/basic-settings/src/basic_settings/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/canvas/canvas-with-llm/src/canvas_with_llm/__init__.py
+++ b/examples/agent-integration/canvas/canvas-with-llm/src/canvas_with_llm/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/canvas/canvas-with-llm/src/canvas_with_llm/agent.py
+++ b/examples/agent-integration/canvas/canvas-with-llm/src/canvas_with_llm/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/citations/citation-basic-usage/src/citation_basic_usage/__init__.py
+++ b/examples/agent-integration/citations/citation-basic-usage/src/citation_basic_usage/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/citations/citation-basic-usage/src/citation_basic_usage/agent.py
+++ b/examples/agent-integration/citations/citation-basic-usage/src/citation_basic_usage/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/env-variables/basic-environment-variables/src/basic_environment_variables/__init__.py
+++ b/examples/agent-integration/env-variables/basic-environment-variables/src/basic_environment_variables/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/env-variables/basic-environment-variables/src/basic_environment_variables/agent.py
+++ b/examples/agent-integration/env-variables/basic-environment-variables/src/basic_environment_variables/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/error/adding-error-context/src/adding_error_context/__init__.py
+++ b/examples/agent-integration/error/adding-error-context/src/adding_error_context/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/error/adding-error-context/src/adding_error_context/agent.py
+++ b/examples/agent-integration/error/adding-error-context/src/adding_error_context/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/error/advanced-error-reporting/src/advanced_error_reporting/__init__.py
+++ b/examples/agent-integration/error/advanced-error-reporting/src/advanced_error_reporting/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/error/advanced-error-reporting/src/advanced_error_reporting/agent.py
+++ b/examples/agent-integration/error/advanced-error-reporting/src/advanced_error_reporting/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/error/multiple-errors-handling/src/multiple_errors_handling/__init__.py
+++ b/examples/agent-integration/error/multiple-errors-handling/src/multiple_errors_handling/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/error/multiple-errors-handling/src/multiple_errors_handling/agent.py
+++ b/examples/agent-integration/error/multiple-errors-handling/src/multiple_errors_handling/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/error/standard-error-reporting/src/standard_error_reporting/__init__.py
+++ b/examples/agent-integration/error/standard-error-reporting/src/standard_error_reporting/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/error/standard-error-reporting/src/standard_error_reporting/agent.py
+++ b/examples/agent-integration/error/standard-error-reporting/src/standard_error_reporting/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/files/file-processing/src/file_processing/__init__.py
+++ b/examples/agent-integration/files/file-processing/src/file_processing/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/files/file-processing/src/file_processing/agent.py
+++ b/examples/agent-integration/files/file-processing/src/file_processing/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/forms/dynamic-form-requests/src/dynamic_form_requests/__init__.py
+++ b/examples/agent-integration/forms/dynamic-form-requests/src/dynamic_form_requests/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/forms/dynamic-form-requests/src/dynamic_form_requests/agent.py
+++ b/examples/agent-integration/forms/dynamic-form-requests/src/dynamic_form_requests/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/forms/initial-form-rendering/src/initial_form_rendering/__init__.py
+++ b/examples/agent-integration/forms/initial-form-rendering/src/initial_form_rendering/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/forms/initial-form-rendering/src/initial_form_rendering/agent.py
+++ b/examples/agent-integration/forms/initial-form-rendering/src/initial_form_rendering/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/llm-proxy-service/llm-access/src/llm_access/__init__.py
+++ b/examples/agent-integration/llm-proxy-service/llm-access/src/llm_access/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/llm-proxy-service/llm-access/src/llm_access/agent.py
+++ b/examples/agent-integration/llm-proxy-service/llm-access/src/llm_access/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/mcp/custom-mcp-client-with-oauth/src/custom_mcp_client_with_oauth/__init__.py
+++ b/examples/agent-integration/mcp/custom-mcp-client-with-oauth/src/custom_mcp_client_with_oauth/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/mcp/custom-mcp-client-with-oauth/src/custom_mcp_client_with_oauth/agent.py
+++ b/examples/agent-integration/mcp/custom-mcp-client-with-oauth/src/custom_mcp_client_with_oauth/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/mcp/github-mcp-agent/src/github_mcp_agent/__init__.py
+++ b/examples/agent-integration/mcp/github-mcp-agent/src/github_mcp_agent/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/mcp/github-mcp-agent/src/github_mcp_agent/agent.py
+++ b/examples/agent-integration/mcp/github-mcp-agent/src/github_mcp_agent/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/examples/agent-integration/multi-turn/advanced-history/src/advanced_history/__init__.py
+++ b/examples/agent-integration/multi-turn/advanced-history/src/advanced_history/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/multi-turn/advanced-history/src/advanced_history/agent.py
+++ b/examples/agent-integration/multi-turn/advanced-history/src/advanced_history/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -23,7 +23,7 @@ FrameworkMessage = UserMessage | AssistantMessage
 
 
 def to_framework_message(message: Message) -> FrameworkMessage:
-    """Convert A2A Message to BeeAI Framework Message format"""
+    """Convert A2A Message to Kagenti ADK Message format"""
     message_text = "".join(part.root.text for part in message.parts if part.root.kind == "text")
 
     if message.role == Role.agent:
@@ -46,7 +46,7 @@ async def advanced_history_example(
     # Load conversation history
     history = [message async for message in context.load_history() if isinstance(message, Message) and message.parts]
 
-    # Initialize BeeAI Framework LLM client
+    # Initialize Kagenti ADK LLM client
     llm_client = AgentStackChatModel(tool_choice_support={"none", "auto"})
     llm_client.set_context(llm)
 

--- a/examples/agent-integration/multi-turn/advanced-history/uv.lock
+++ b/examples/agent-integration/multi-turn/advanced-history/uv.lock
@@ -39,7 +39,7 @@ name = "advanced-history"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "agentstack-sdk" },
+    { name = "kagenti-adk" },
     { name = "beeai-framework", extra = ["a2a", "duckduckgo", "wikipedia"] },
     { name = "fastuuid" },
     { name = "pyyaml" },
@@ -54,7 +54,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agentstack-sdk", editable = "../../../../apps/adk-py" },
+    { name = "kagenti-adk", editable = "../../../../apps/adk-py" },
     { name = "beeai-framework", extras = ["duckduckgo", "wikipedia", "a2a"], specifier = "==0.1.78" },
     { name = "fastuuid", specifier = ">=0.14.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -68,7 +68,7 @@ dev = [
 ]
 
 [[package]]
-name = "agentstack-sdk"
+name = "kagenti-adk"
 version = "0.6.3"
 source = { editable = "../../../../apps/adk-py" }
 dependencies = [

--- a/examples/agent-integration/multi-turn/basic-history/src/basic_history/__init__.py
+++ b/examples/agent-integration/multi-turn/basic-history/src/basic_history/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/multi-turn/basic-history/src/basic_history/agent.py
+++ b/examples/agent-integration/multi-turn/basic-history/src/basic_history/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/multi-turn/streaming-agent-history/src/streaming_agent_history/__init__.py
+++ b/examples/agent-integration/multi-turn/streaming-agent-history/src/streaming_agent_history/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0

--- a/examples/agent-integration/multi-turn/streaming-agent-history/src/streaming_agent_history/agent.py
+++ b/examples/agent-integration/multi-turn/streaming-agent-history/src/streaming_agent_history/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 import os

--- a/examples/agent-integration/multi-turn/streaming-agent-history/uv.lock
+++ b/examples/agent-integration/multi-turn/streaming-agent-history/uv.lock
@@ -35,7 +35,7 @@ telemetry = [
 ]
 
 [[package]]
-name = "agentstack-sdk"
+name = "kagenti-adk"
 version = "0.6.3"
 source = { editable = "../../../../apps/adk-py" }
 dependencies = [
@@ -1900,7 +1900,7 @@ name = "streaming-agent-history"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "agentstack-sdk" },
+    { name = "kagenti-adk" },
     { name = "beeai-framework", extra = ["a2a", "duckduckgo", "wikipedia"] },
     { name = "fastuuid" },
     { name = "pyyaml" },
@@ -1915,7 +1915,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agentstack-sdk", editable = "../../../../apps/adk-py" },
+    { name = "kagenti-adk", editable = "../../../../apps/adk-py" },
     { name = "beeai-framework", extras = ["duckduckgo", "wikipedia", "a2a"], specifier = "==0.1.78" },
     { name = "fastuuid", specifier = ">=0.14.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },

--- a/examples/agent-integration/overview/advanced-server-wrapper/src/advanced_server_wrapper/__init__.py
+++ b/examples/agent-integration/overview/advanced-server-wrapper/src/advanced_server_wrapper/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/overview/advanced-server-wrapper/src/advanced_server_wrapper/agent.py
+++ b/examples/agent-integration/overview/advanced-server-wrapper/src/advanced_server_wrapper/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/overview/dependency-injection/src/dependency_injection/__init__.py
+++ b/examples/agent-integration/overview/dependency-injection/src/dependency_injection/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/overview/dependency-injection/src/dependency_injection/agent.py
+++ b/examples/agent-integration/overview/dependency-injection/src/dependency_injection/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/overview/server-wrapper/src/server_wrapper/__init__.py
+++ b/examples/agent-integration/overview/server-wrapper/src/server_wrapper/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/overview/server-wrapper/src/server_wrapper/agent.py
+++ b/examples/agent-integration/overview/server-wrapper/src/server_wrapper/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/__init__.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/agent.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/embedding/__init__.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/embedding/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/embedding/client.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/embedding/client.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.a2a.extensions import EmbeddingServiceExtensionServer

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/embedding/embed.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/embedding/embed.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.platform import File, VectorStoreItem

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/extraction.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/extraction.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/text_splitting.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/text_splitting.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from langchain_text_splitters import MarkdownTextSplitter

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/vector_store/__init__.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/vector_store/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/vector_store/create.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/vector_store/create.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.platform import VectorStore

--- a/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/vector_store/search.py
+++ b/examples/agent-integration/rag/conversation-rag-agent/src/conversation_rag_agent/vector_store/search.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.platform import VectorStore, VectorStoreSearchResult

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/__init__.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/agent.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/embedding/__init__.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/embedding/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/embedding/client.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/embedding/client.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.a2a.extensions import EmbeddingServiceExtensionServer

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/embedding/embed.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/embedding/embed.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.platform import File, VectorStoreItem

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/extraction.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/extraction.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/text_splitting.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/text_splitting.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from langchain_text_splitters import MarkdownTextSplitter

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/vector_store/__init__.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/vector_store/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/vector_store/create.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/vector_store/create.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.platform import VectorStore

--- a/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/vector_store/search.py
+++ b/examples/agent-integration/rag/simple-rag-agent/src/simple_rag_agent/vector_store/search.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 from kagenti_adk.platform import VectorStore, VectorStoreSearchResult

--- a/examples/agent-integration/secrets/basic-secrets/src/basic_secrets/__init__.py
+++ b/examples/agent-integration/secrets/basic-secrets/src/basic_secrets/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/secrets/basic-secrets/src/basic_secrets/agent.py
+++ b/examples/agent-integration/secrets/basic-secrets/src/basic_secrets/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/agent-integration/tool-calls/basic-approve/src/basic_approve/__init__.py
+++ b/examples/agent-integration/tool-calls/basic-approve/src/basic_approve/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/tool-calls/basic-approve/src/basic_approve/agent.py
+++ b/examples/agent-integration/tool-calls/basic-approve/src/basic_approve/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 import os
 from typing import Annotated, Any

--- a/examples/agent-integration/trajectory/trajectory-basic-usage/src/trajectory_basic_usage/__init__.py
+++ b/examples/agent-integration/trajectory/trajectory-basic-usage/src/trajectory_basic_usage/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/agent-integration/trajectory/trajectory-basic-usage/src/trajectory_basic_usage/agent.py
+++ b/examples/agent-integration/trajectory/trajectory-basic-usage/src/trajectory_basic_usage/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/examples/deploy-agents/building-agents/implement-your-agent-logic/src/implement_your_agent_logic/__init__.py
+++ b/examples/deploy-agents/building-agents/implement-your-agent-logic/src/implement_your_agent_logic/__init__.py
@@ -1,3 +1,3 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 

--- a/examples/deploy-agents/building-agents/implement-your-agent-logic/src/implement_your_agent_logic/agent.py
+++ b/examples/deploy-agents/building-agents/implement-your-agent-logic/src/implement_your_agent_logic/agent.py
@@ -1,4 +1,4 @@
-# Copyright 2025 © BeeAI a Series of LF Projects, LLC
+# Copyright 2025 © Kagenti a Series of LF Projects, LLC
 # SPDX-License-Identifier: Apache-2.0
 
 import os


### PR DESCRIPTION
## Summary
Update all examples and docs to reflect the new Kagenti ADK branding:
- Copyright headers: BeeAI -> Kagenti across all Python files
- String literals: framework name and author references updated
- Comments: BeeAI Framework -> Kagenti ADK in code comments
- uv.lock: agentstack-sdk -> kagenti-adk in lockfiles
- Docs: auto-synced embedded code snippets

## Linked Issues
Closes: https://github.com/kagenti/adk/issues/29


## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.