### PR TITLE
fix(cli): use local image tags for platform start

### DIFF
--- a/apps/adk-cli/src/kagenti_cli/commands/platform.py
+++ b/apps/adk-cli/src/kagenti_cli/commands/platform.py
@@ -501,11 +501,15 @@ async def start_cmd(
                         "providerBuilds": {"enabled": True},
                         "disableProviderDownscaling": True,
                         "server": {
+                            "image": {"tag": "local"},
                             "cors": {
                                 "enabled": True,
                                 "allowOriginRegex": r"https?://(localhost|127\.0\.0\.1|[a-z0-9.-]*\.?localtest\.me)(:\d+)?",
                                 "allowCredentials": True,
                             },
+                        },
+                        "ui": {
+                            "image": {"tag": "local"},
                         },
                     },
                     user_values.get("kagenti-adk", {}),


### PR DESCRIPTION
## Summary
- The `platform start` command was not setting image tags, so helm defaulted to `appVersion` (0.7.1) which doesn't exist on ghcr.io
- Locally-built images use the `local` tag (`ghcr.io/kagenti/adk/adk-server:local`, `ghcr.io/kagenti/adk/adk-ui:local`)
- Set `server.image.tag` and `ui.image.tag` to `"local"` in the helm values passed by `platform start`

## Test plan
- [ ] Run `kagenti-adk platform start` and verify it uses `:local` images instead of `:0.7.1`