### PR TITLE
refactor: rename agentstack: task prefixes to adk:

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -34,7 +34,7 @@ If you encounter a name length error when starting VM, shorten the name and retr
 - Project commands (`mise`, `uv run`, `pnpm`, etc.) run **inside the VM** using `limactl shell <vm-name> -- <command>`.
 - Absolute path of worktree is same on host and guest, cwd is preserved by `limactl shell`.
 - Use the normal Edit/Write tools directly on `.worktrees/<branch>/...` paths.
-- To start the platform: `limactl shell <vm-name> -- mise run agentstack:start`
+- To start the platform: `limactl shell <vm-name> -- mise run adk:start`
 - Keep iterating until the feature is working and validated.
 
 ## When user confirms work is done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,28 +49,28 @@ will use
 Instead, use:
 
 ```shell
-mise agentstack:start
+mise adk:start
 ```
 
 This will build the images (`adk-server` and `adk-ui`) and import them to the cluster. You can add other
 CLI arguments as you normally would when using `kagenti-adk` CLI, for example:
 
 ```shell
-mise agentstack:start --set docling.enabled=true --set oidc.enabled=true
+mise adk:start --set docling.enabled=true --set oidc.enabled=true
 ```
 
 To stop or delete the platform use
 
 ```shell
-mise agentstack:stop
-mise agentstack:delete
+mise adk:stop
+mise adk:delete
 ```
 
 For debugging and direct access to kubernetes, setup `KUBECONFIG` and other environment variables using:
 
 ```shell
 # Activate environment
-eval "$(mise run agentstack:shell)"
+eval "$(mise run adk:shell)"
 
 # Deactivate environment
 deactivate
@@ -83,7 +83,7 @@ By default, authentication and authorization are disabled.
 Starting the platform with OIDC enabled:
 
 ```bash
-mise agentstack:start --set auth.enabled=true
+mise adk:start --set auth.enabled=true
 ```
 
 This will setup keycloak (with no platform users out of the box).
@@ -111,7 +111,7 @@ keycloak:
         enabled: true
 ```
 
-Then run `mise run agentstack:start -f config.yaml`
+Then run `mise run adk:start -f config.yaml`
 
 **Available endpoints:**
 

--- a/apps/adk-server/tasks.toml
+++ b/apps/adk-server/tasks.toml
@@ -176,7 +176,7 @@ run = "{{ mise_bin }} run adk-server:migrations:alembic revision --autogenerate 
 
 ["adk-server:dev:shell"]
 dir = "{{config_root}}/apps/adk-server"
-run = "{{ mise_bin }} run agentstack:shell --vm-name=agentstack-local-dev"
+run = "{{ mise_bin }} run adk:shell --vm-name=agentstack-local-dev"
 
 ["adk-server:dev:start"]
 dir = "{{config_root}}/apps/adk-server"
@@ -189,12 +189,12 @@ run = """
 
 set -e
 VM_NAME="${usage_vm_name?}"
-eval "$( {{ mise_bin }} run agentstack:shell --vm-name="$VM_NAME" )"
+eval "$( {{ mise_bin }} run adk:shell --vm-name="$VM_NAME" )"
 {{ mise_bin }} run adk-server:dev:disconnect --vm-name="$VM_NAME"
-{{ mise_bin }} run agentstack:stop-all --except "$VM_NAME"
+{{ mise_bin }} run adk:stop-all --except "$VM_NAME"
 eval "cli_args=(${usage_cli_args})"
 export SKIP_PULL
-{{ mise_bin }} agentstack:start --vm-name="$VM_NAME" \
+{{ mise_bin }} adk:start --vm-name="$VM_NAME" \
     --no-wait-for-platform \
     "${cli_args[@]}"
 {{ mise_bin }} run adk-server:dev:connect --vm-name="$VM_NAME"
@@ -220,7 +220,7 @@ run = """
 #!/bin/bash
 VM_NAME="${usage_vm_name?}"
 {{ mise_bin }} run adk-server:dev:disconnect --vm-name="$VM_NAME"
-{{ mise_bin }} run agentstack:stop --vm-name="$VM_NAME"
+{{ mise_bin }} run adk:stop --vm-name="$VM_NAME"
 """
 
 ["adk-server:dev:delete"]
@@ -238,7 +238,7 @@ run = """
 #!/bin/bash
 NAMESPACE=kagenti-adk
 VM_NAME="${usage_vm_name?}"
-eval "$( {{ mise_bin }} run agentstack:shell --vm-name="$VM_NAME" )"
+eval "$( {{ mise_bin }} run adk:shell --vm-name="$VM_NAME" )"
 
 # MicroShift/OpenShift specific setup for Telepresence
 kubectl create namespace ambassador --dry-run=client -o yaml | kubectl apply -f -
@@ -290,7 +290,7 @@ run = """
 #!/bin/bash
 NAMESPACE=kagenti-adk
 VM_NAME="${usage_vm_name?}"
-eval "$( {{ mise_bin }} run agentstack:shell --vm-name="$VM_NAME" )"
+eval "$( {{ mise_bin }} run adk:shell --vm-name="$VM_NAME" )"
 
 tele="telepresence --use .*${NAMESPACE}.*"
 if ! ($tele status --output json | jq '.user_daemon.status' | grep -q "Not connected"); then
@@ -331,8 +331,8 @@ export KAGENTI_ADK_CLIENT_ID=kagenti-cli
 
 NO_CLEAN="${usage_no_clean:-false}"
 if [ "$NO_CLEAN" != "true" ]; then
-    {{ mise_bin }} run agentstack:stop-all
-    {{ mise_bin }} run agentstack:delete --vm-name=${VM_NAME} || true
+    {{ mise_bin }} run adk:stop-all
+    {{ mise_bin }} run adk:delete --vm-name=${VM_NAME} || true
     curl http://kagenti-api.localtest.me:8080 >/dev/null 2>&1 && echo "Another instance at kagenti-api.localtest.me:8080 is already running" && exit 2
 fi
 
@@ -346,9 +346,9 @@ agentstack:
     enabled: true
 ' > "$CONFIG_FILE"
 
-{{ mise_bin }} run agentstack:start -v --vm-name=${VM_NAME} --skip-login -f "$CONFIG_FILE"
+{{ mise_bin }} run adk:start -v --vm-name=${VM_NAME} --skip-login -f "$CONFIG_FILE"
 
-eval "$( {{ mise_bin }} run agentstack:shell --vm-name="$VM_NAME" )"
+eval "$( {{ mise_bin }} run adk:shell --vm-name="$VM_NAME" )"
 
 if [ -z "${TEST_AGENT_IMAGE:-}" ]; then
     echo "Building test agent..."
@@ -398,8 +398,8 @@ export KAGENTI_ADK_CLIENT_ID=kagenti-cli
 
 NO_CLEAN="${usage_no_clean:-false}"
 if [ "$NO_CLEAN" != "true" ]; then
-    {{ mise_bin }} run agentstack:stop-all
-    {{ mise_bin }} run agentstack:delete --vm-name=${VM_NAME}
+    {{ mise_bin }} run adk:stop-all
+    {{ mise_bin }} run adk:delete --vm-name=${VM_NAME}
     curl http://kagenti-api.localtest.me:8080 >/dev/null 2>&1 && echo "Another instance at kagenti-api.localtest.me:8080 is already running" && exit 2
 fi
 
@@ -413,10 +413,10 @@ agentstack:
     enabled: true
 ' > "$CONFIG_FILE"
 
-{{ mise_bin }} run agentstack:start --vm-name=${VM_NAME} --skip-login -f "$CONFIG_FILE"
+{{ mise_bin }} run adk:start --vm-name=${VM_NAME} --skip-login -f "$CONFIG_FILE"
 
 
-eval "$( {{ mise_bin }} run agentstack:shell --vm-name="$VM_NAME" )"
+eval "$( {{ mise_bin }} run adk:shell --vm-name="$VM_NAME" )"
 
 export DB_URL="postgresql+asyncpg://adk-user:password@localhost:5432/adk"
 export LLM_API_BASE="${LLM_API_BASE:-http://host.docker.internal:11434/v1}"
@@ -459,14 +459,14 @@ run = """
 set -euxo pipefail
 VM_NAME=integration-test-run
 
-# {{ mise_bin }} run agentstack:delete --vm-name="$VM_NAME"
+# {{ mise_bin }} run adk:delete --vm-name="$VM_NAME"
 
-{{ mise_bin }} run agentstack:start \
+{{ mise_bin }} run adk:start \
     --vm-name="$VM_NAME" \
     --set kagenti-adk:redis.enabled=true \
     --set kagenti-adk:ui.enabled=false
 
-eval "$( {{ mise_bin }} run agentstack:shell --vm-name="$VM_NAME" )"
+eval "$( {{ mise_bin }} run adk:shell --vm-name="$VM_NAME" )"
 
 {{ mise_bin }} run adk-server:dev:disconnect --vm-name="$VM_NAME"
 {{ mise_bin }} run adk-server:dev:connect --vm-name="$VM_NAME"

--- a/tasks.toml
+++ b/tasks.toml
@@ -132,7 +132,7 @@ run = "true" # Empty tests in case there are no tests
 
 # platform tasks
 
-["agentstack:start"]
+["adk:start"]
 depends = [
   "adk-server:build",
   "microshift-vm:build:qemu",
@@ -171,13 +171,13 @@ fi
     ${UI_TAG-} "$@"
 """
 
-["agentstack:delete"]
+["adk:delete"]
 run = "{{ mise_bin }} run adk-cli:run -- platform delete"
 
-["agentstack:stop"]
+["adk:stop"]
 run = "{{ mise_bin }} run adk-cli:run -- platform stop"
 
-["agentstack:stop-all"]
+["adk:stop-all"]
 usage = 'flag "--except <except>" default=""'
 run = """
 #!/bin/bash
@@ -194,7 +194,7 @@ echo "$TO_STOP" | xargs -rn 1 -I"{}" mise run adk-cli:run -- platform stop --vm-
 {% endraw %}
 """
 
-["agentstack:shell"]
+["adk:shell"]
 raw = true
 dir = "{{cwd}}"
 usage = 'flag "--vm-name <vm_name>" default="agentstack"'


### PR DESCRIPTION
## Summary

- Rename all `agentstack:*` mise task prefixes to `adk:*` in root `tasks.toml` and `apps/adk-server/tasks.toml`
- Update corresponding task references in `CONTRIBUTING.md` and `.claude/skills/worktree/SKILL.md`
- YAML Helm config values (`agentstack:\n  ui:`) are intentionally unchanged — they reference chart keys, not task names

## Test plan

- [ ] Verify `grep -r 'agentstack:' tasks.toml apps/adk-server/tasks.toml CONTRIBUTING.md .claude/skills/worktree/SKILL.md` returns only the two Helm YAML config blocks in `apps/adk-server/tasks.toml`
- [ ] Run `mise ls --tasks | grep adk:` to confirm tasks are recognized under the new prefix
- [ ] Run `mise run adk:shell` to verify task execution works