### PR TITLE
feat(cli): add 'admin' command to launch Kagenti admin console

### DIFF
--- a/apps/adk-cli/src/kagenti_cli/__init__.py
+++ b/apps/adk-cli/src/kagenti_cli/__init__.py
@@ -179,13 +179,13 @@ async def admin():
 
     if active_server:
         if "localtest.me" in active_server:
-            admin_url = re.sub(r"://[^:/]+\.localtest\.me", "://keycloak.localtest.me", active_server)
+            admin_url = re.sub(r"://[^:/]+\.localtest\.me", "://kagenti-ui.localtest.me", active_server)
         elif re.search(r"(localhost|127\.0\.0\.1):8333", active_server):
-            admin_url = re.sub(r"(localhost|127\.0\.0\.1):8333", "keycloak.localtest.me:8080", active_server)
+            admin_url = re.sub(r"(localhost|127\.0\.0\.1):8333", "kagenti-ui.localtest.me:8080", active_server)
         else:
             admin_url = active_server
     else:
-        admin_url = "http://keycloak.localtest.me:8080"
+        admin_url = "http://kagenti-ui.localtest.me:8080"
 
     webbrowser.open(admin_url)
 


### PR DESCRIPTION
## Summary
- Adds a new `admin` CLI command that opens the Kagenti admin console GUI in the browser
- Derives the admin console URL from the active server configuration (localtest.me, localhost, or remote)
- Updates the CLI help text to include the new command

Closes #37

## Test plan
- [ ] Run `kagenti-adk admin` with a localtest.me server configured — should open `kagenti-ui.localtest.me`
- [ ] Run `kagenti-adk admin` with no server configured — should default to `http://kagenti-ui.localtest.me:8080`
- [ ] Run `kagenti-adk admin` with a localhost:8333 server — should map to `kagenti-ui.localtest.me:8080`
- [ ] Verify `kagenti-adk --help` shows the new `admin` command