### PR TITLE
fix(ui): resolve various errors following rebrand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,7 @@ mise.local.toml
 # Claude
 .claude/tasks
 .claude/worktrees
+**/.claude/settings.local.json
 
 # pnpm store gets created in-tree in VMs
 .pnpm-store

--- a/apps/adk-ui/src/api/adk-client.ts
+++ b/apps/adk-ui/src/api/adk-client.ts
@@ -19,7 +19,7 @@ function buildAuthenticatedAdkClient() {
     const request = new Request(url, init);
 
     if (isAuthEnabled) {
-      const token = await ensureToken(request);
+      const token = await ensureToken();
 
       if (token?.accessToken) {
         request.headers.set('Authorization', `Bearer ${token.accessToken}`);

--- a/apps/adk-ui/src/app/(auth)/auth.ts
+++ b/apps/adk-ui/src/app/(auth)/auth.ts
@@ -95,6 +95,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: provider ? [provider] : [],
   pages: {
     signIn: routes.signIn(),
+    error: routes.signIn(),
   },
   session: { strategy: 'jwt' },
   trustHost: true,

--- a/apps/adk-ui/src/app/(auth)/rsc.tsx
+++ b/apps/adk-ui/src/app/(auth)/rsc.tsx
@@ -16,7 +16,7 @@ import { routes } from '#utils/router.ts';
 
 import { auth, AUTH_COOKIE_NAME, AUTH_SECRET } from './auth';
 
-export async function ensureToken(request: Request) {
+export async function ensureToken() {
   const { isAuthEnabled } = runtimeConfig;
 
   if (!isAuthEnabled) {
@@ -28,13 +28,12 @@ export async function ensureToken(request: Request) {
     return null;
   }
 
-  // Ensure we have auth cookie, because it's not included in RSC requests
-  if (!request.headers.get('cookie')?.includes(`${AUTH_COOKIE_NAME}=`)) {
-    const cookieStore = await cookies();
-    request.headers.set('cookie', cookieStore.toString());
-  }
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+  // Synthetic request with cookies from next/headers — getToken only reads cookies, not the URL
+  const req = new Request('https://n', { headers: { cookie: cookieHeader } });
 
-  const token = await getToken({ req: request, cookieName: AUTH_COOKIE_NAME, secret: AUTH_SECRET });
+  const token = await getToken({ req, cookieName: AUTH_COOKIE_NAME, secret: AUTH_SECRET });
 
   return token;
 }

--- a/apps/adk-ui/src/app/(auth)/signin/page.tsx
+++ b/apps/adk-ui/src/app/(auth)/signin/page.tsx
@@ -6,11 +6,11 @@
 import { SignInView } from '#modules/auth/components/SignInView.tsx';
 
 interface Props {
-  searchParams: Promise<{ callbackUrl?: string }>;
+  searchParams: Promise<{ callbackUrl?: string; error?: string }>;
 }
 
 export default async function SignInPage({ searchParams }: Props) {
-  const { callbackUrl } = await searchParams;
+  const { callbackUrl, error } = await searchParams;
 
-  return <SignInView callbackUrl={callbackUrl} />;
+  return <SignInView callbackUrl={callbackUrl} error={error} />;
 }

--- a/apps/adk-ui/src/app/api/[...path]/route.ts
+++ b/apps/adk-ui/src/app/api/[...path]/route.ts
@@ -39,7 +39,7 @@ async function handler(request: NextRequest, context: RouteContext) {
       return;
     }
 
-    const token = await ensureToken(request);
+    const token = await ensureToken();
 
     if (!token?.accessToken) {
       return new NextResponse('Unauthorized', { status: 401 });

--- a/apps/adk-ui/src/app/icon.svg
+++ b/apps/adk-ui/src/app/icon.svg
@@ -1,0 +1,9 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<style>
+  path { fill: black; }
+  @media (prefers-color-scheme: dark) {
+    path { fill: white; }
+  }
+</style>
+<path d="M29 28H3V26.1538H29V28ZM26.2143 18.7692H5.78571V20.6154H26.2143V18.7692ZM23.4286 11.3846H8.57143V13.2308H23.4286V11.3846ZM20.6429 4H11.3571V5.84615H20.6429V4Z"/>
+</svg>

--- a/apps/adk-ui/src/app/layout.tsx
+++ b/apps/adk-ui/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { connection } from 'next/server';
 import { AppProvider } from '#contexts/App/AppProvider.tsx';
 import { runtimeConfig } from '#contexts/App/runtime-config.ts';
 import Providers from '#providers.tsx';
-import { APP_FAVICON_SVG, APP_FAVICON_SVG_DARK, BASE_PATH, THEME_STORAGE_KEY } from '#utils/constants.ts';
+import { THEME_STORAGE_KEY } from '#utils/constants.ts';
 
 const darkModeScript = `
 (() => {
@@ -32,14 +32,8 @@ const darkModeScript = `
 })();
 `;
 
-const icon = `${BASE_PATH}${APP_FAVICON_SVG}`;
-const darkIcon = `${BASE_PATH}${APP_FAVICON_SVG_DARK}`;
-
 export const metadata: Metadata = {
   title: runtimeConfig.appName,
-  icons: {
-    icon: [{ url: icon }, { url: darkIcon, media: '(prefers-color-scheme: dark)' }],
-  },
 };
 
 export default async function RootLayout({

--- a/apps/adk-ui/src/modules/auth/components/SignInError.tsx
+++ b/apps/adk-ui/src/modules/auth/components/SignInError.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026 © IBM Corp.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use client';
+
+import { Button, InlineNotification } from '@carbon/react';
+import { useRouter } from 'next/navigation';
+
+import { routes } from '#utils/router.ts';
+
+import classes from './AuthErrorPage.module.scss';
+
+interface Props {
+  message: string;
+  callbackUrl?: string;
+}
+
+export function SignInError({ message, callbackUrl = routes.home() }: Props) {
+  const router = useRouter();
+
+  return (
+    <div className={classes.root}>
+      <InlineNotification
+        kind="error"
+        title="Authentication Error"
+        subtitle={message}
+        hideCloseButton
+        lowContrast
+      />
+      <Button kind="primary" onClick={() => router.push(routes.signIn({ callbackUrl }))}>
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/adk-ui/src/modules/auth/components/SignInProviders.tsx
+++ b/apps/adk-ui/src/modules/auth/components/SignInProviders.tsx
@@ -3,25 +3,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { redirect } from 'next/navigation';
-import { AuthError } from 'next-auth';
-
 import { auth, getProvider, signIn } from '#app/(auth)/auth.ts';
 import type { ThemePreference } from '#contexts/Theme/theme-context.ts';
 import { routes } from '#utils/router.ts';
 
 import { AuthErrorPage } from './AuthErrorPage';
 import { AutoSignIn } from './AutoSignIn';
+import { SignInError } from './SignInError';
 
 interface Props {
   callbackUrl?: string;
+  error?: string;
 }
 
 const authProvider = getProvider();
 
-export async function SignInProviders({ callbackUrl = routes.home() }: Props) {
+export async function SignInProviders({ callbackUrl = routes.home(), error }: Props) {
   if (!authProvider) {
     return null;
+  }
+
+  if (error) {
+    const message = AUTH_ERROR_MESSAGES[error] ?? 'An unexpected authentication error occurred. Please try again.';
+    return <SignInError message={message} callbackUrl={callbackUrl} />;
   }
 
   const session = await auth();
@@ -44,11 +48,16 @@ async function handleSignIn(
     await signIn(providerId, { redirectTo }, { kc_theme: theme });
   } catch (error) {
     // Sign-in can fail for a number of reasons, such as the user not existing, or the user not having the correct role.
-    // In some cases, you may want to redirect to a custom error.
-    if (error instanceof AuthError) {
-      return redirect(routes.error({ error }));
-    }
-
+    // NextAuth redirects to the error page for auth errors (e.g. Configuration when the provider is unreachable).
+    // Re-throw to let Next.js handle the redirect.
     throw error;
   }
 }
+
+
+const AUTH_ERROR_MESSAGES: Record<string, string> = {
+  Configuration:
+    'Unable to connect to the identity provider. Please verify that the authentication service is running and correctly configured.',
+  IdentityProviderUnavailable:
+    'Unable to connect to the identity provider. Please verify that the authentication service is running and try again.',
+};

--- a/apps/adk-ui/src/modules/auth/components/SignInView.tsx
+++ b/apps/adk-ui/src/modules/auth/components/SignInView.tsx
@@ -11,15 +11,16 @@ import classes from './SignInView.module.scss';
 
 interface Props {
   callbackUrl?: string;
+  error?: string;
 }
 
-export function SignInView({ callbackUrl }: Props) {
+export function SignInView({ callbackUrl, error }: Props) {
   return (
     <div className={classes.root}>
       <Container size="full" className={classes.container}>
         <SignInHeading />
 
-        <SignInProviders callbackUrl={callbackUrl} />
+        <SignInProviders callbackUrl={callbackUrl} error={error} />
       </Container>
     </div>
   );

--- a/apps/adk-ui/template.env
+++ b/apps/adk-ui/template.env
@@ -29,10 +29,10 @@ OIDC_PROVIDER_NAME=Keycloak
 OIDC_PROVIDER_ID=keycloak
 OIDC_PROVIDER_CLIENT_ID=adk-ui
 OIDC_PROVIDER_CLIENT_SECRET=adk-ui-secret
-OIDC_PROVIDER_ISSUER=http://keycloak.localtest.me:8080
+OIDC_PROVIDER_ISSUER=http://keycloak.localtest.me:8080/realms/adk
 # defaults to OIDC_PROVIDER_ISSUER if not set — only needed when internal and public URLs differ (e.g. dev mode)
-OIDC_PROVIDER_EXTERNAL_ISSUER=http://keycloak.localtest.me:8080
+OIDC_PROVIDER_EXTERNAL_ISSUER=http://keycloak.localtest.me:8080/realms/adk
 
 # next-auth random string
 NEXTAUTH_SECRET=
-NEXTAUTH_URL="http://adk.localtest.me:8080"
+NEXTAUTH_URL="http://localhost:3000"

--- a/kagenti-adk.code-workspace
+++ b/kagenti-adk.code-workspace
@@ -25,10 +25,6 @@
       "path": "apps/adk-ui",
     },
     {
-      "name": "keycloak-theme",
-      "path": "apps/keycloak-theme",
-    },
-    {
       "name": "agent-chat",
       "path": "agents/chat",
     },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,7 +58,6 @@ packages:
   - apps/adk-ts
   # TODO: Uncomment, when published to npm
   # - apps/adk-ts/examples/chat-ui
-  - apps/keycloak-theme
   - docs
 
 catalog:


### PR DESCRIPTION
## Summary
- Fix Keycloak OIDC issuer URLs to include `/realms/adk` path
- Fix token retrieval in RSC and API route contexts by reading cookies from `next/headers` instead of the incoming request
- Show user-friendly auth error messages on the sign-in page instead of a generic error page
- Replace favicon metadata with new Next.js convention - `icon.svg` placed in `src/app` and make it dark scheme aware
- Remove `keycloak-theme` package
- Rename workspace file to `kagenti-adk.code-workspace`

## Linked Issues
Closes #82 

## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.