### PR TITLE
fix(ui): remove unused favicon constants and env variables

### DIFF
--- a/apps/adk-ui/src/utils/constants.ts
+++ b/apps/adk-ui/src/utils/constants.ts
@@ -7,10 +7,6 @@ export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 
 export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
 
-export const APP_FAVICON_SVG = process.env.NEXT_PUBLIC_APP_FAVICON_SVG ?? '/favicon.svg';
-
-export const APP_FAVICON_SVG_DARK = process.env.NEXT_PUBLIC_APP_FAVICON_SVG_DARK ?? '/favicon-dark.svg';
-
 export const API_URL = process.env.API_URL ?? 'http://adk-api.localtest.me:8080';
 
 export const PROD_MODE = process.env.NODE_ENV === 'production';

--- a/apps/adk-ui/template.env
+++ b/apps/adk-ui/template.env
@@ -17,12 +17,6 @@ NEXT_PUBLIC_BASE_URL=
 # Default: ''
 NEXT_PUBLIC_BASE_PATH=
 
-# Default: '/favicon.svg'
-NEXT_PUBLIC_APP_FAVICON_SVG=
-
-# Default: '/favicon-dark.svg'
-NEXT_PUBLIC_APP_FAVICON_SVG_DARK=
-
 # Default true
 OIDC_ENABLED=true
 OIDC_PROVIDER_NAME=Keycloak


### PR DESCRIPTION
## Summary
  - Remove unused APP_FAVICON_SVG and APP_FAVICON_SVG_DARK constants from constants.ts
  - Remove corresponding NEXT_PUBLIC_APP_FAVICON_SVG and NEXT_PUBLIC_APP_FAVICON_SVG_DARK env variables from template.env

## Linked Issues
Follows up on #86, which stopped using these constants but left them defined.


## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.