### PR TITLE
chore: group dependabot updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,23 +4,43 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: uv
     directory: /apps/adk-server
     schedule:
       interval: weekly
+    groups:
+      adk-server-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: uv
     directory: /apps/adk-cli
     schedule:
       interval: weekly
+    groups:
+      adk-cli-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: uv
     directory: /apps/adk-py
     schedule:
       interval: weekly
+    groups:
+      adk-py-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Add `groups` configuration to dependabot so each ecosystem produces **one bundled PR per week** instead of one PR per dependency
- Reduces PR noise from potentially dozens of individual dependency update PRs to at most 5 (one per ecosystem: github-actions, npm, adk-server, adk-cli, adk-py)

## Test plan
- [ ] Verify dependabot creates grouped PRs on next weekly run