### PR TITLE
chore: bump kagenti and kagenti-deps charts to 0.6.0-alpha.2

### DIFF
--- a/apps/adk-cli/src/kagenti_cli/commands/platform.py
+++ b/apps/adk-cli/src/kagenti_cli/commands/platform.py
@@ -561,7 +561,7 @@ async def start_cmd(
             ).encode("utf-8"),
         )
         # --- Prepare kagenti chart values and version before image listing ---
-        kagenti_chart_version = "0.5.0-alpha.11"
+        kagenti_chart_version = "0.6.0-alpha.2"
         kagenti_deps_values = yaml.dump(
             merge(
                 {


### PR DESCRIPTION
## Summary
- Bump kagenti and kagenti-deps chart version from `0.5.0-alpha.11` to `0.6.0-alpha.2`

## Changes in 0.6.0-alpha.2
- Operator bumped to 0.2.0-alpha.22, webhook to 0.4.0-alpha.9
- RBAC role constants and hierarchy support (auth foundation)
- AuthBridge configmaps now created in user namespaces
- Pinned sidecar image tags (fixes proxy-init crash)
- A2A agents deployable with Kagenti UI disabled
- Configurable domain name (replaces hardcoded localtest.me)
- MLflow integration for LLM trace observability

## Test plan
- [ ] CI pipeline passes
- [ ] `kagenti-adk platform start` deploys successfully with new chart versions

- [x] No Docs Needed