### PR TITLE
fix(adk-ts): fix infinite recursion in JSONRPC SSE client ID generation

### DIFF
--- a/apps/adk-ts/src/client/a2a/transport/jsonrpc-sse-client.ts
+++ b/apps/adk-ts/src/client/a2a/transport/jsonrpc-sse-client.ts
@@ -11,7 +11,7 @@ import type { A2AClient, CreateA2AClientParams } from './types';
 
 function generateId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return generateId();
+    return crypto.randomUUID();
   }
   // Fallback for non-secure contexts (e.g. HTTP in browsers)
   return `${Date.now()}-${Math.random().toString(36).slice(2)}`;


### PR DESCRIPTION
## Summary
Fixes bug introduced in #194 that the JSONRPC SSE client was non-functional without this fix

## Linked Issues
## Documentation
- [x] No Docs Needed:

If this PR adds new feature or changes existing. Make sure documentation is adjusted accordingly. If the docs is not needed, please explain why.