### PR TITLE
ci: Add org-wide project automation workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,24 @@
+name: Kagenti Project Automation
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  add:
+    name: Add item to Kagenti Project
+
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+
+    # Pinned to @main intentionally: org-internal workflows propagate updates automatically.
+    uses: kagenti/.github/.github/workflows/add-to-project.yml@main
+    secrets: inherit
+

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -18,7 +18,5 @@ jobs:
       pull-requests: write
       contents: read
 
-    # Pinned to @main intentionally: org-internal workflows propagate updates automatically.
-    uses: kagenti/.github/.github/workflows/add-to-project.yml@main
+    uses: kagenti/.github/.github/workflows/add-to-project.yml@8ec0d357da0f51a4e4d67b26eb5a9a887604cf6d  # main
     secrets: inherit
-


### PR DESCRIPTION
## Summary

- Add thin caller for the org-wide project automation workflow from kagenti/.github
- Auto-adds new issues and PRs to the kagenti prioritization project

Closes #213

Matches kagenti/kagenti#1253.

## Note on SHA pinning

Other kagenti repos (kagenti, kagenti-extensions, etc.) use `@main` for org-internal
reusable workflows so that upstream improvements propagate automatically
(see [kagenti/agentic-control-plane#23](https://github.com/kagenti/agentic-control-plane/pull/23)
for the rationale). However, this repo's `Verify Action Pinning` CI check hard-fails
on `@main` references (unlike kagenti/kagenti where the same check is informational
only). Rather than modifying this repo's CI policy, the reusable workflow is pinned
to a specific SHA to comply with the existing check.