### PR TITLE
docs(adk-py): fix broken 'See [Documentation]' link to docs overview

### DIFF
--- a/apps/adk-py/README.md
+++ b/apps/adk-py/README.md
@@ -69,7 +69,7 @@ The SDK includes extension support for:
 - **Trajectory** - Agent decision logging (`TrajectoryExtensionServer`, `TrajectoryExtensionSpec`)
 - **LLM Services** - Platform-managed language models (`LLMServiceExtensionServer`, `LLMServiceExtensionSpec`)
 - **Agent Details** - Metadata and UI enhancements (`AgentDetail`)
-- **And more** - See [Documentation](https://github.com/kagenti/adk/blob/main/docs/stable/agent-development/overview)
+- **And more** - See [Documentation](https://github.com/kagenti/adk/blob/main/docs/stable/sdk/overview.mdx)
 
 Each extension provides both server-side handlers and A2A protocol specifications for seamless integration with Kagenti ADK's UI and infrastructure.
 


### PR DESCRIPTION
## Summary

\`apps/adk-py/README.md:72\` pointed the 'And more - See [Documentation]' link at \`docs/stable/agent-development/overview\`, which does not exist in the repo. The actual SDK overview file is \`docs/stable/sdk/overview.mdx\`. Re-targeted the link there.

Closes #205

## Testing

Docs-only change. Verified \`docs/stable/sdk/overview.mdx\` exists on main (alongside \`docs/development/sdk/overview.mdx\`); no other README link was touched.