### PR TITLE
docs(adk-py): drop broken Discussions link (feature not enabled on repo)

### DIFF
--- a/apps/adk-py/README.md
+++ b/apps/adk-py/README.md
@@ -86,7 +86,6 @@ Contributions are welcome! Please see the [Contributing Guide](https://github.co
 ## Support
 
 - [GitHub Issues](https://github.com/kagenti/adk/issues)
-- [GitHub Discussions](https://github.com/kagenti/adk/discussions)
 
 ---
 


### PR DESCRIPTION
## Summary

\`apps/adk-py/README.md:89\` (the *Support* section) linked to \`https://github.com/kagenti/adk/discussions\`, but Discussions aren't enabled on this repo — the URL 404s. Dropped that bullet. GitHub Issues (line 88) remains as the primary support channel.

If the project plans to enable Discussions, happy to re-add the link in a follow-up.

Closes #206

## Testing

Docs-only change, single bullet removed.