### PR TITLE
docs: Fix 2 broken internal link(s) in adk

### DIFF
--- a/skills/kagenti-adk-wrapper/references/platform-extensions.md
+++ b/skills/kagenti-adk-wrapper/references/platform-extensions.md
@@ -21,7 +21,7 @@ Use this reference for selecting and implementing Kagenti ADK platform extension
 | **Canvas**            | Needs to edit artifacts or code selected by the user                                                     | [Work with Canvas](https://github.com/kagenti/adk/blob/main/docs/stable/agent-integration/canvas.mdx)                                                                                                                                            |
 | **Citations**         | References documents or external URLs                                                                    | [Add Citations to Agent Responses](https://github.com/kagenti/adk/blob/main/docs/stable/agent-integration/citations.mdx)                                                                                                                         |
 
-For a complete overview of all available extensions: **[Agent Integration Overview](https://github.com/kagenti/adk/blob/main/docs/stable/agent-integration/overview.mdx)**
+For a complete overview of all available extensions: **[Agent Integration Overview](https://github.com/kagenti/adk/blob/main/docs/stable/sdk/overview.mdx)**
 
 ## Configuration & Secret Guidance Location
 

--- a/skills/kagenti-adk-wrapper/references/trajectory.md
+++ b/skills/kagenti-adk-wrapper/references/trajectory.md
@@ -16,7 +16,7 @@ Trajectory entries are metadata for transparency and observability. They are not
 
 ## Trajectory Implementation
 
-When implementing trajectories, follow the [Trajectory Documentation](https://github.com/kagenti/adk/blob/main/docs/stable/agent-integration/trajectory.mdx) and utilize these patterns:
+When implementing trajectories, follow the [Trajectory Documentation](https://github.com/kagenti/adk/blob/main/docs/stable/sdk/trajectory.mdx) and utilize these patterns:
 
 - **Import**: `from kagenti_adk.a2a.extensions import TrajectoryExtensionServer, TrajectoryExtensionSpec`
 - **Injection**: `trajectory: Annotated[TrajectoryExtensionServer, TrajectoryExtensionSpec()]` as an agent function parameter.


### PR DESCRIPTION
Automated fix by OpenClaw Link Health Fixer.
Broken internal links updated to point to current file locations.

| File | Old Path | New Path |
|------|----------|----------|
| `skills/kagenti-adk-wrapper/references/trajectory.md` | `docs/stable/agent-integration/trajectory.mdx` | `docs/stable/sdk/trajectory.mdx` |
| `skills/kagenti-adk-wrapper/references/platform-extensions.md` | `docs/stable/agent-integration/overview.mdx` | `docs/stable/sdk/overview.mdx` |