### PR TITLE
docs: Remove broken discussions link from adk-py README

### DIFF
--- a/apps/adk-py/README.md
+++ b/apps/adk-py/README.md
@@ -86,7 +86,6 @@ Contributions are welcome! Please see the [Contributing Guide](https://github.co
 ## Support
 
 - [GitHub Issues](https://github.com/kagenti/adk/issues)
-- [GitHub Discussions](https://github.com/kagenti/adk/discussions)
 
 ---
 


### PR DESCRIPTION
Automated fix by OpenClaw Link Health Fixer.

GitHub Discussions is not enabled on `kagenti/adk`, causing the discussions link in `apps/adk-py/README.md` to return 404. Removed the dead link; the GitHub Issues link remains for support.

| File | Change |
|------|--------|
| `apps/adk-py/README.md` | Removed dead `/discussions` link |

Closes #206